### PR TITLE
Get the default prefix from git configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+
+0.2 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#2`_, `#5`_: get the default prefix from git configuration
+
+.. _#2: https://github.com/RKrahl/git-attic/issues/2
+.. _#5: https://github.com/RKrahl/git-attic/pull/5
+
+
 0.1 (2021-04-11)
 ~~~~~~~~~~~~~~~~
 

--- a/doc/src/man-git-attic.rst
+++ b/doc/src/man-git-attic.rst
@@ -69,6 +69,16 @@ Options
     reference.
 
 
+Configuration variables
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following git configuration settings can be used to modify
+**git attic** behavior.
+
+attic.prefix
+    Set the default prefix for the references in the archive.
+
+
 See also
 ~~~~~~~~
 

--- a/scripts/git-attic.py
+++ b/scripts/git-attic.py
@@ -10,6 +10,10 @@ def _rungit(cmd):
                   check=True, universal_newlines=True)
     return subprocess.run(cmd, **kwargs)
 
+def config_get_prefix():
+    proc = _rungit("git config --default attic --get attic.prefix".split())
+    return proc.stdout.strip()
+
 def listrefs(args):
     prefix = 'refs/%s/' % args.prefix
     if args.verbose:
@@ -59,7 +63,8 @@ def fetch(args):
 def main():
     description = "Manage an archive of retired references"
     argparser = argparse.ArgumentParser(description=description)
-    argparser.add_argument('--prefix', default="attic", help="archive prefix")
+    argparser.add_argument('--prefix', default=config_get_prefix(),
+                           help="archive prefix")
     subparsers = argparser.add_subparsers(title='subcommands', dest='subcmd')
     listparser = subparsers.add_parser('list', help="list references")
     listparser.add_argument('-v', action='store_true', dest='verbose',

--- a/tests/test_03_config_prefix.py
+++ b/tests/test_03_config_prefix.py
@@ -1,0 +1,75 @@
+"""Test setting the default prefix in the git config.
+
+Similar to test_01_stash_restore.py: test list, stash and restore
+subcommands of git-attic, but set another default prefix in the git
+config.
+"""
+
+import pytest
+from conftest import *
+
+@pytest.fixture(scope="function")
+def configured_gitrepo(gitrepo):
+    cmd = ('git', '-C', str(gitrepo),
+           'config', '--local', '--add', 'attic.prefix', 'barn')
+    run_cmd(cmd)
+    return gitrepo
+
+def test_config_stash_and_restore_simple(monkeypatch, configured_gitrepo):
+    """Stash and restore in the most simple case.
+    """
+    monkeypatch.chdir(configured_gitrepo)
+    assert_refs(git_attic(("list", "-v")), ())
+    assert_refs(git_branches(), get_test_branches())
+
+    git_attic(("stash", "hawaii"))
+    assert_refs(git_attic(("list", "-v")),
+                get_test_branches(("hawaii",)))
+    assert_refs(git_branches(),
+                get_test_branches(("marinara", "master")))
+
+    git_attic(("stash", "marinara"))
+    assert_refs(git_attic(("list", "-v")),
+                get_test_branches(("hawaii", "marinara")))
+    assert_refs(git_attic(("--prefix", "barn", "list", "-v")),
+                get_test_branches(("hawaii", "marinara")))
+    assert_refs(git_branches(),
+                get_test_branches(("master",)))
+    assert set(git_attic(("list",)).stdout.split()) == {"hawaii", "marinara"}
+
+    git_attic(("restore", "marinara"))
+    assert_refs(git_attic(("list", "-v")),
+                get_test_branches(("hawaii", "marinara")))
+    assert_refs(git_branches(),
+                get_test_branches(("marinara", "master")))
+
+def test_config_stash_and_restore_prefix(monkeypatch, configured_gitrepo):
+    """Use an alternative prefix.
+    """
+    monkeypatch.chdir(configured_gitrepo)
+    assert_refs(git_attic(("list", "-v")), ())
+    assert_refs(git_branches(), get_test_branches())
+
+    git_attic(("--prefix", "archive", "stash", "hawaii"))
+    assert_refs(git_attic(("--prefix", "archive", "list", "-v")),
+                get_test_branches(("hawaii",)))
+    assert_refs(git_attic(("list", "-v")), ())
+    assert_refs(git_branches(),
+                get_test_branches(("marinara", "master")))
+
+    git_attic(("--prefix", "shed", "stash", "marinara"))
+    assert_refs(git_attic(("--prefix", "shed", "list", "-v")),
+                get_test_branches(("marinara",)))
+    assert_refs(git_attic(("--prefix", "archive", "list", "-v")),
+                get_test_branches(("hawaii",)))
+    assert_refs(git_attic(("list", "-v")), ())
+    assert_refs(git_branches(),
+                get_test_branches(("master",)))
+    refs = git_attic(("--prefix", "archive", "list")).stdout.split()
+    assert set(refs) == {"hawaii"}
+
+    git_attic(("--prefix", "shed", "restore", "marinara"))
+    assert_refs(git_attic(("--prefix", "shed", "list", "-v")),
+                get_test_branches(("marinara",)))
+    assert_refs(git_branches(),
+                get_test_branches(("marinara", "master")))


### PR DESCRIPTION
Read the git configuration variable `attic.prefix` to set the default prefix for the references in the archive. The built-in default `attic` will still be used if that configuration variable is not set.

Close #2.